### PR TITLE
ABSPATHをCONTENT_DIRに書き換える

### DIFF
--- a/includes/class-NephilaClavata.php
+++ b/includes/class-NephilaClavata.php
@@ -434,17 +434,19 @@ class NephilaClavata {
         $sizes = $this->get_attachment_sizes($attachment_id);
         $images = array();
         foreach ($sizes as $size) {
-            $home_path = function_exists('get_home_path') ? get_home_path() : ABSPATH;
+            $content_path = WP_CONTENT_DIR;
+            $content_url = WP_CONTENT_URL;
+
             if ( $image_src = wp_get_attachment_image_src($attachment_id, $size) ) {
                 $images[$size] = array(
                     'url'    => $image_src[0],
-                    'file'   => str_replace(site_url('/'), $home_path, $image_src[0]),
+                    'file'   => str_replace($content_url, $content_path, $image_src[0]),
                     's3_key' => preg_replace('#https?://[^/]*/#i', '/', $image_src[0]),
                 );
             } elseif ($attachment_url = wp_get_attachment_url($attachment_id, $size) ) {
                 $images[$size] = array(
                     'url'    => $attachment_url,
-                    'file'   => str_replace(site_url('/'), $home_path, $attachment_url),
+                    'file'   => str_replace($content_url, $content_path, $attachment_url),
                     's3_key' => preg_replace('#https?://[^/]*/#i', '/', $attachment_url),
                 );
             }


### PR DESCRIPTION
諸事情でWordPressのcoreファイルとcontentsファイルを分けて管理する必要があり、
WordPress-skelton(https://github.com/markjaquith/WordPress-Skeleton)のようなファイル構造にしているのですが、その環境ではnephila-clavataが動作しませんでした。

これはclass-NephilaClavata.phpで、サーバでの画像の絶対パスをABSPATHを用いて求めているのが原因で、ABSPATHをWP_CONTENT_DIRに置き換え、それに伴っていくつか書き換えたところ正常に動くようになりました。

素のWordPressでの動作確認もしております。可能なら本家の方でも取り込んでもらえると助かります。
