### PR TITLE
WP_CONTENT_DIR定数ではなく、wp_upload_dir() 関数を利用する

### DIFF
--- a/includes/class-NephilaClavata.php
+++ b/includes/class-NephilaClavata.php
@@ -434,8 +434,9 @@ class NephilaClavata {
         $sizes = $this->get_attachment_sizes($attachment_id);
         $images = array();
         foreach ($sizes as $size) {
-            $content_path = WP_CONTENT_DIR;
-            $content_url = WP_CONTENT_URL;
+            $upload_dir_config = wp_upload_dir();
+            $content_path = $upload_dir_config['basedir'];
+            $content_url = $upload_dir_config['baseurl'];
 
             if ( $image_src = wp_get_attachment_image_src($attachment_id, $size) ) {
                 $images[$size] = array(


### PR DESCRIPTION
UPLOADS 定数を指定してメディアのアップロード先を変更している環境でPHPエラーが発生する。
NephilaClavata クラス の get_s3_media_info() でURLからpathに置換する際にうまく置換されていなかった。
そのため、S3_helper クラスの download() のところで file_put_contents() するときに第1引数がURLのままとなりPHPエラーが発生する。

wp-config.php で UPLOADS定数を使ってメディアのアップロード先を変更した場合にWP_CONTENT_DIR定数、WP_CONTENT_URL定数では正しく取得できないので、 wp_upload_dir() を利用するように変更。