### PR TITLE
The fourth argument is not better..

### DIFF
--- a/includes/class-NephilaClavata.php
+++ b/includes/class-NephilaClavata.php
@@ -258,7 +258,7 @@ class NephilaClavata {
 			dbgx_trace_var($replace_data_org);
 		}
 		if ($post_id && ($replace_data !== $replace_data_org))
-			update_post_meta($post_id, $post_meta_key, array($s3_bucket => $replace_data), true);
+			update_post_meta($post_id, $post_meta_key, array($s3_bucket => $replace_data));
 		unset($S3_medias_new);
 		unset($S3_medias_old);
 		unset($S3_medias);


### PR DESCRIPTION
## change from

##### update_post_meta($post_id, $post_meta_key, array($s3_bucket => $replace_data), true);

↓

`
UPDATE wp_postmeta SET meta_value = 'hogehoge' WHERE post_id = 13208 AND meta_key = '_s3_media_files-replace' AND meta_value = '1';
`

`AND meta_value = 1` => 0 row ...

## change to

##### update_post_meta($post_id, $post_meta_key, array($s3_bucket => $replace_data));

↓

`
UPDATE wp_postmeta SET meta_value = 'hogehoge' WHERE post_id = 13208 AND meta_key = '_s3_media_files-replace';
`

:smiley: 

